### PR TITLE
Add support for SDXL model

### DIFF
--- a/scripts/tokenizer.py
+++ b/scripts/tokenizer.py
@@ -6,16 +6,15 @@ import gradio as gr
 
 css = """
 .tokenizer-token{
+    opacity: 0.8;
     cursor: pointer;
+    --body-text-color: #000;
 }
-.tokenizer-token-0 {background: rgba(255, 0, 0, 0.05);}
-.tokenizer-token-0:hover {background: rgba(255, 0, 0, 0.15);}
-.tokenizer-token-1 {background: rgba(0, 255, 0, 0.05);}
-.tokenizer-token-1:hover {background: rgba(0, 255, 0, 0.15);}
-.tokenizer-token-2 {background: rgba(0, 0, 255, 0.05);}
-.tokenizer-token-2:hover {background: rgba(0, 0, 255, 0.15);}
-.tokenizer-token-3 {background: rgba(255, 156, 0, 0.05);}
-.tokenizer-token-3:hover {background: rgba(255, 156, 0, 0.15);}
+.tokenizer-token:hover {opacity: 1;}
+.tokenizer-token-0 {background: var(--primary-300);}
+.tokenizer-token-1 {background: var(--primary-400);}
+.tokenizer-token-2 {background: var(--primary-500);}
+.tokenizer-token-3 {background: var(--primary-600);}
 """
 
 


### PR DESCRIPTION
This extension works with the SD1.5 models but fails with SDXL. In this code update, I checked the source code and identified that SDXL at this line: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/feee37d75f1b168768014e4634dcb156ee649c05/modules/sd_hijack_clip.py#L349.

The current logic only checks `shared.sd_model.cond_stage_model.wrapped`, while the hijacked SDXL `FrozenCLIPEmbedderForSDXLWithCustomWords` is located in `shared.sd_model.cond_stage_model.embedders[0].wrapped`.

I lack the technical expertise to confirm differences in the tokenizer. However, SD1.5 and SDXL appear to produce the same ID, source code also suggests the vocab maps to Unicode, making any model suitable.

In this pull request, I refactored the logic so `VanillaClip` and `OpenClip` no longer depend on instance checks. They now verify the required attribute. I passed `embedders[index].wrapped` to the Clip classes, so the first matching attribute is used for tokenization. Since SDXL and SD1.5 produce the same tokenization, I didn't include logic to identify the best "embedder" (which should be `FrozenCLIPEmbedderForSDXLWithCustomWords`), as they likely yield the same result.


Lastly, token colors were barely visible in dark theme. I updated them to use the theme color instead of hardcoded RGB.

<img width="500" alt="Screenshot 2024-06-13 at 18 15 04" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui-tokenizer/assets/10471270/a735ebf9-3cbf-416e-b6fc-f4269dbbe932">

<img width="500" alt="Screenshot 2024-06-13 at 18 15 15" src="https://github.com/AUTOMATIC1111/stable-diffusion-webui-tokenizer/assets/10471270/f41d0143-c1ba-4d22-9a26-c756331ea5e3">
